### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/tarka/vicarian/compare/v0.1.0...v0.1.1) - 2025-12-22
+
+### Other
+
+- Remove obsolete external directory.
+- Re-allow external readme file.
+- Use explicit job steps.
+- Another attempt
+- Try removing dispatch.
+- Simplify dispatch.
+- More workflow tweaks
+- Workflow tweaks
+- Spit manual and automatic steps.
+- Initial release-plz configuration.
+- Add fuzzyness to cert renewal timeout.
+- Correct wait period conversion.
+- Example config update
+- Conf docs updates.
+- Bump dependencies.
+- More tightening-up of the config file format.
+- More documentation updates.
+- Correct corn link
+- Updates to example config files and add a draft CONFIGURATION.md
+- Fixes to service file.
+- Make tx end of quit queue private.
+- Watcher cleanup.
+- Cleanup handling of ACME certificate configuration and expiry handling.
+- Normalise all time calculations on Chrono and second resolution.
+- Add ability to trust a HTTPS backend with self-signed certs.
+- Reduce request logging.
+- Header cleanup.
+- Add Via: header
+- Logging cleanup.
+- Dogfooding with the new shortlived ACME profile.
+- Initial support for application context handling.
+- Big refactor of cert handling that removes the assumption of Subject: being the hostname. This also allows us to use the 'tlscert' profile, and 'shortlived' eventually.
+- Use local instant-acme with our patches for the time being.
+- Better handling of expiring certs.
+- Handle hosts with multiple aliases.
+- Fixes from adding locally
+- Re-add handling multiple authorisations.
+- Remove erroneous option check on insert.
+- Update and expand example configs.
+- First cut of HTTP-01 challenge response.
+- Start of refactoring to support ACME HTTP-01
+- Remove domain from config in favour of calcuating it from the PSL.
+- Add loading and saving account credentials.
+- Update zone-update
+- Zone-updated reverted API changes.
+- Move to new zone-update API, plus misc. cleanups.
+- Update gitignore.
+- Dependency bump
+- Move config into config dir and split out tests.
+- Move proxy tests into own submodule.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3784,7 +3784,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vicarian"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vicarian"
 description = "Vicarian is a reverse proxy server with ACME support"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 authors = ["Steve Smith <tarkasteve@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `vicarian`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/tarka/vicarian/compare/v0.1.0...v0.1.1) - 2025-12-22

### Other

- Remove obsolete external directory.
- Re-allow external readme file.
- Use explicit job steps.
- Another attempt
- Try removing dispatch.
- Simplify dispatch.
- More workflow tweaks
- Workflow tweaks
- Spit manual and automatic steps.
- Initial release-plz configuration.
- Add fuzzyness to cert renewal timeout.
- Correct wait period conversion.
- Example config update
- Conf docs updates.
- Bump dependencies.
- More tightening-up of the config file format.
- More documentation updates.
- Correct corn link
- Updates to example config files and add a draft CONFIGURATION.md
- Fixes to service file.
- Make tx end of quit queue private.
- Watcher cleanup.
- Cleanup handling of ACME certificate configuration and expiry handling.
- Normalise all time calculations on Chrono and second resolution.
- Add ability to trust a HTTPS backend with self-signed certs.
- Reduce request logging.
- Header cleanup.
- Add Via: header
- Logging cleanup.
- Dogfooding with the new shortlived ACME profile.
- Initial support for application context handling.
- Big refactor of cert handling that removes the assumption of Subject: being the hostname. This also allows us to use the 'tlscert' profile, and 'shortlived' eventually.
- Use local instant-acme with our patches for the time being.
- Better handling of expiring certs.
- Handle hosts with multiple aliases.
- Fixes from adding locally
- Re-add handling multiple authorisations.
- Remove erroneous option check on insert.
- Update and expand example configs.
- First cut of HTTP-01 challenge response.
- Start of refactoring to support ACME HTTP-01
- Remove domain from config in favour of calcuating it from the PSL.
- Add loading and saving account credentials.
- Update zone-update
- Zone-updated reverted API changes.
- Move to new zone-update API, plus misc. cleanups.
- Update gitignore.
- Dependency bump
- Move config into config dir and split out tests.
- Move proxy tests into own submodule.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).