### PR TITLE
chore: release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/tarka/vicarian/compare/v0.1.4...v0.1.5) - 2025-12-22
+
+### Other
+
+- Try only running release on PR merge.
+- Disable Mac & FreeBSD binaries for now until we have testing for them in place.
+
 ## [0.1.4](https://github.com/tarka/vicarian/compare/v0.1.3...v0.1.4) - 2025-12-22
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3784,7 +3784,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vicarian"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vicarian"
 description = "Vicarian is a reverse proxy server with ACME support"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 
 authors = ["Steve Smith <tarkasteve@gmail.com>"]


### PR DESCRIPTION


## 🤖 New release

* `vicarian`: 0.1.4 -> 0.1.5

This is a test addition to the PR notes.

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.5](https://github.com/tarka/vicarian/compare/v0.1.4...v0.1.5) - 2025-12-22

### Other

- Try only running release on PR merge.
- Disable Mac & FreeBSD binaries for now until we have testing for them in place.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).