### PR TITLE
chore: release v0.1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.16](https://github.com/tarka/vicarian/compare/v0.1.15...v0.1.16) - 2026-01-08
+
+### Other
+
+- Add not about tech stack.
+- Expand on static file updates.
+- Update to recommend static-web-server over python.
+- Soften the tone in AI section.
+- minor readme updates.
+- Add note about tarball layout.
+
 ## [0.1.15](https://github.com/tarka/vicarian/compare/v0.1.14...v0.1.15) - 2026-01-07
 
 ## Notable changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4015,7 +4015,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vicarian"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vicarian"
 description = "Vicarian is a reverse proxy server with ACME support"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 
 authors = ["Steve Smith <tarkasteve@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `vicarian`: 0.1.15 -> 0.1.16

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.16](https://github.com/tarka/vicarian/compare/v0.1.15...v0.1.16) - 2026-01-08

### Other

- Add not about tech stack.
- Expand on static file updates.
- Update to recommend static-web-server over python.
- Soften the tone in AI section.
- minor readme updates.
- Add note about tarball layout.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).