### PR TITLE
chore: release v0.1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.17](https://github.com/tarka/vicarian/compare/v0.1.16...v0.1.17) - 2026-01-08
+
+### Other
+
+- Add notes about HTTP/3 and h2c.
+- Add HTTP/2 support and testing.
+- Simplify tls-only references.
+
 ## [0.1.16](https://github.com/tarka/vicarian/compare/v0.1.15...v0.1.16) - 2026-01-08
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4016,7 +4016,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vicarian"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vicarian"
 description = "Vicarian is a reverse proxy server with ACME support"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 
 authors = ["Steve Smith <tarkasteve@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `vicarian`: 0.1.16 -> 0.1.17

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.17](https://github.com/tarka/vicarian/compare/v0.1.16...v0.1.17) - 2026-01-08

### Other

- Add notes about HTTP/3 and h2c.
- Add HTTP/2 support and testing.
- Simplify tls-only references.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).