### PR TITLE
chore: release v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/tarka/vicarian/compare/v0.2.5...v0.2.6) - 2026-05-09
+
+### <!-- 1 -->Bug Fixes
+
+- Handle hostnames case-insensitively
+
+### Other
+
+- Dependency upgrade
+- Dependency bump.
+- Add ACME renewal success/fail counters.
+- Move metrics names into consts in metrics module and register/describe them up front.
+- Minor dependency updates.
+- Update github action version.
+
 ## [0.2.5](https://github.com/tarka/vicarian/compare/v0.2.4...v0.2.5) - 2026-03-11
 
 ### <!-- 0 -->Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/tarka/vicarian/compare/v0.2.5...v0.2.6) - 2026-05-26
+
+### <!-- 1 -->Bug Fixes
+
+- Add fix for bare-IPv6 port-stripping.
+- Handle hostnames case-insensitively
+
+### Other
+
+- Add LLM-generated corner-case testing. One failing currently.
+- Minor test fix
+- Dependency upgrade
+- Dependency bump.
+- Add ACME renewal success/fail counters.
+- Move metrics names into consts in metrics module and register/describe them up front.
+- Minor dependency updates.
+- Update github action version.
+
 ## [0.2.5](https://github.com/tarka/vicarian/compare/v0.2.4...v0.2.5) - 2026-03-11
 
 ### <!-- 0 -->Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4328,7 +4328,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vicarian"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vicarian"
 description = "Vicarian is a reverse proxy server with ACME support"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2024"
 
 authors = ["Steve Smith <tarkasteve@gmail.com>"]

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -95,8 +95,15 @@ fn rewrite_port(host: &str, newport: &str) -> String {
 }
 
 fn strip_port(host_header: &str) -> &str {
-    if let Some(i) = host_header.rfind(':') {
-        &host_header[0..i]
+    if host_header.starts_with('[') {
+        // IPv6-literal special case
+        if let Some(pos) = host_header.find("]:") {
+            &host_header[..pos + 1]
+        } else {
+            host_header
+        }
+    } else if let Some(i) = host_header.rfind(':') {
+        &host_header[..i]
     } else {
         host_header
     }

--- a/src/proxy/tests.rs
+++ b/src/proxy/tests.rs
@@ -113,3 +113,576 @@ fn test_router() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_router_overlapping_prefixes() -> Result<()> {
+    let backends = vec![
+        Backend {
+            context: Some("/api".to_string()),
+            url: Uri::from_static("http://localhost:1010"),
+            trust: false,
+            auth_key: None,
+        },
+        Backend {
+            context: Some("/api/v2".to_string()),
+            url: Uri::from_static("http://localhost:2020"),
+            trust: false,
+            auth_key: None,
+        },
+        Backend {
+            context: None,
+            url: Uri::from_static("http://localhost:9999"),
+            trust: false,
+            auth_key: None,
+        },
+    ];
+
+    let router = Router::new(&backends);
+
+    let matched = router.lookup("/api/v2").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:2020"), matched.backend.url);
+    assert_eq!("", matched._path);
+
+    let matched = router.lookup("/api/v2/").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:2020"), matched.backend.url);
+    assert_eq!("/", matched._path);
+
+    let matched = router.lookup("/api/v2/deep").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:2020"), matched.backend.url);
+    assert_eq!("/deep", matched._path);
+
+    let matched = router.lookup("/api").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:1010"), matched.backend.url);
+    assert_eq!("", matched._path);
+
+    let matched = router.lookup("/api/").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:1010"), matched.backend.url);
+    assert_eq!("/", matched._path);
+
+    let matched = router.lookup("/api/deep").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:1010"), matched.backend.url);
+    assert_eq!("/deep", matched._path);
+
+    Ok(())
+}
+
+#[test]
+fn test_router_prefix_ambiguity() -> Result<()> {
+    let backends = vec![
+        Backend {
+            context: Some("/api".to_string()),
+            url: Uri::from_static("http://localhost:1010"),
+            trust: false,
+            auth_key: None,
+        },
+        Backend {
+            context: Some("/api2".to_string()),
+            url: Uri::from_static("http://localhost:2020"),
+            trust: false,
+            auth_key: None,
+        },
+        Backend {
+            context: Some("/api1".to_string()),
+            url: Uri::from_static("http://localhost:3030"),
+            trust: false,
+            auth_key: None,
+        },
+        Backend {
+            context: None,
+            url: Uri::from_static("http://localhost:9999"),
+            trust: false,
+            auth_key: None,
+        },
+    ];
+
+    let router = Router::new(&backends);
+
+    let matched = router.lookup("/api").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:1010"), matched.backend.url);
+    assert_eq!("", matched._path);
+
+    let matched = router.lookup("/api/").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:1010"), matched.backend.url);
+    assert_eq!("/", matched._path);
+
+    let matched = router.lookup("/api/deep").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:1010"), matched.backend.url);
+    assert_eq!("/deep", matched._path);
+
+    let matched = router.lookup("/api2").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:2020"), matched.backend.url);
+    assert_eq!("", matched._path);
+
+    let matched = router.lookup("/api2/").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:2020"), matched.backend.url);
+    assert_eq!("/", matched._path);
+
+    let matched = router.lookup("/api2/deep").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:2020"), matched.backend.url);
+    assert_eq!("/deep", matched._path);
+
+    let matched = router.lookup("/api1").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:3030"), matched.backend.url);
+    assert_eq!("", matched._path);
+
+    let matched = router.lookup("/api1/").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:3030"), matched.backend.url);
+    assert_eq!("/", matched._path);
+
+    let matched = router.lookup("/api1/deep").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:3030"), matched.backend.url);
+    assert_eq!("/deep", matched._path);
+
+    let matched = router.lookup("/other").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:9999"), matched.backend.url);
+    assert_eq!("other", matched._path);
+
+    Ok(())
+}
+
+#[test]
+fn test_router_empty_backends() -> Result<()> {
+    let backends: Vec<Backend> = vec![];
+    let router = Router::new(&backends);
+    assert!(router.lookup("/anything").is_none());
+    Ok(())
+}
+
+#[test]
+fn test_router_no_default_backend() -> Result<()> {
+    let backends = vec![
+        Backend {
+            context: Some("/service".to_string()),
+            url: Uri::from_static("http://localhost:1010"),
+            trust: false,
+            auth_key: None,
+        },
+    ];
+    let router = Router::new(&backends);
+    assert!(router.lookup("/other").is_none());
+    assert!(router.lookup("/").is_none());
+    Ok(())
+}
+
+#[test]
+fn test_router_empty_context() -> Result<()> {
+    let backends = vec![
+        Backend {
+            context: Some("".to_string()),
+            url: Uri::from_static("http://localhost:1010"),
+            trust: false,
+            auth_key: None,
+        },
+    ];
+    let router = Router::new(&backends);
+    let matched = router.lookup("/anything").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:1010"), matched.backend.url);
+    Ok(())
+}
+
+#[test]
+fn test_router_slash_context() -> Result<()> {
+    let backends = vec![
+        Backend {
+            context: Some("/".to_string()),
+            url: Uri::from_static("http://localhost:1010"),
+            trust: false,
+            auth_key: None,
+        },
+    ];
+    let router = Router::new(&backends);
+    let matched = router.lookup("/anything").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:1010"), matched.backend.url);
+    assert_eq!("anything", matched._path);
+    Ok(())
+}
+
+#[test]
+fn test_router_no_leading_slash() -> Result<()> {
+    let backends = vec![
+        Backend {
+            context: Some("service".to_string()),
+            url: Uri::from_static("http://localhost:1010"),
+            trust: false,
+            auth_key: None,
+        },
+    ];
+    let router = Router::new(&backends);
+    assert!(router.lookup("/service/deep").is_none());
+    Ok(())
+}
+
+#[test]
+fn test_router_duplicate_contexts() -> Result<()> {
+    let backends = vec![
+        Backend {
+            context: Some("/x".to_string()),
+            url: Uri::from_static("http://localhost:1010"),
+            trust: false,
+            auth_key: None,
+        },
+        Backend {
+            context: Some("/x".to_string()),
+            url: Uri::from_static("http://localhost:2020"),
+            trust: false,
+            auth_key: None,
+        },
+    ];
+    let router = Router::new(&backends);
+    let matched = router.lookup("/x").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:2020"), matched.backend.url);
+    assert_eq!("", matched._path);
+    Ok(())
+}
+
+#[test]
+fn test_router_three_level_overlap() -> Result<()> {
+    let backends = vec![
+        Backend {
+            context: Some("/api".to_string()),
+            url: Uri::from_static("http://localhost:1010"),
+            trust: false,
+            auth_key: None,
+        },
+        Backend {
+            context: Some("/api/v2".to_string()),
+            url: Uri::from_static("http://localhost:2020"),
+            trust: false,
+            auth_key: None,
+        },
+        Backend {
+            context: Some("/api/v2/deep".to_string()),
+            url: Uri::from_static("http://localhost:3030"),
+            trust: false,
+            auth_key: None,
+        },
+        Backend {
+            context: None,
+            url: Uri::from_static("http://localhost:9999"),
+            trust: false,
+            auth_key: None,
+        },
+    ];
+    let router = Router::new(&backends);
+
+    let matched = router.lookup("/api/v2/deep/extra").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:3030"), matched.backend.url);
+    assert_eq!("/extra", matched._path);
+
+    let matched = router.lookup("/api/v2").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:2020"), matched.backend.url);
+    assert_eq!("", matched._path);
+
+    let matched = router.lookup("/api").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:1010"), matched.backend.url);
+    assert_eq!("", matched._path);
+
+    let matched = router.lookup("/api/v3").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:1010"), matched.backend.url);
+    assert_eq!("/v3", matched._path);
+
+    let matched = router.lookup("/other").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:9999"), matched.backend.url);
+    assert_eq!("other", matched._path);
+
+    Ok(())
+}
+
+#[test]
+fn test_router_query_string() -> Result<()> {
+    let backends = vec![
+        Backend {
+            context: Some("/service".to_string()),
+            url: Uri::from_static("http://localhost:1010"),
+            trust: false,
+            auth_key: None,
+        },
+    ];
+    let router = Router::new(&backends);
+    let matched = router.lookup("/service?foo=bar").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:1010"), matched.backend.url);
+    assert_eq!("?foo=bar", matched._path);
+    Ok(())
+}
+
+#[test]
+fn test_router_fragment() -> Result<()> {
+    let backends = vec![
+        Backend {
+            context: Some("/service".to_string()),
+            url: Uri::from_static("http://localhost:1010"),
+            trust: false,
+            auth_key: None,
+        },
+    ];
+    let router = Router::new(&backends);
+    let matched = router.lookup("/service#section").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:1010"), matched.backend.url);
+    assert_eq!("#section", matched._path);
+    Ok(())
+}
+
+#[test]
+fn test_router_path_traversal() -> Result<()> {
+    let backends = vec![
+        Backend {
+            context: Some("/service".to_string()),
+            url: Uri::from_static("http://localhost:1010"),
+            trust: false,
+            auth_key: None,
+        },
+    ];
+    let router = Router::new(&backends);
+    let matched = router.lookup("/service/../other").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:1010"), matched.backend.url);
+    assert_eq!("/../other", matched._path);
+    Ok(())
+}
+
+#[test]
+fn test_rewrite_port_ipv6() -> Result<()> {
+    let replaced = rewrite_port("[::1]:8080", "443");
+    assert_eq!("[::1]:443", replaced);
+
+    let replaced = rewrite_port("[::1]", "443");
+    assert_eq!("[::1]", replaced);
+
+    Ok(())
+}
+
+#[test]
+fn test_rewrite_port_edge_cases() -> Result<()> {
+    let replaced = rewrite_port("a:b:c", "80");
+    assert_eq!("a:b:c", replaced);
+
+    let replaced = rewrite_port("", "80");
+    assert_eq!("", replaced);
+
+    Ok(())
+}
+
+#[test]
+fn test_strip_port_ipv6() -> Result<()> {
+    let host = strip_port("[::1]:8080");
+    assert_eq!("[::1]", host);
+
+    let host = strip_port("[::1]");
+    assert_eq!("[::1]", host);
+
+    Ok(())
+}
+
+#[test]
+fn test_router_empty_path() -> Result<()> {
+    let backends = vec![
+        Backend {
+            context: None,
+            url: Uri::from_static("http://localhost:1010"),
+            trust: false,
+            auth_key: None,
+        },
+    ];
+    let router = Router::new(&backends);
+    let matched = router.lookup("").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:1010"), matched.backend.url);
+    assert_eq!("", matched._path);
+    Ok(())
+}
+
+#[test]
+fn test_router_double_slash_prefix() -> Result<()> {
+    let backends = vec![
+        Backend {
+            context: Some("/service".to_string()),
+            url: Uri::from_static("http://localhost:1010"),
+            trust: false,
+            auth_key: None,
+        },
+        Backend {
+            context: None,
+            url: Uri::from_static("http://localhost:9999"),
+            trust: false,
+            auth_key: None,
+        },
+    ];
+    let router = Router::new(&backends);
+    let matched = router.lookup("//").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:9999"), matched.backend.url);
+    let matched = router.lookup("//service/foo").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:9999"), matched.backend.url);
+    Ok(())
+}
+
+#[test]
+fn test_router_double_slash_in_path() -> Result<()> {
+    let backends = vec![
+        Backend {
+            context: Some("/service".to_string()),
+            url: Uri::from_static("http://localhost:1010"),
+            trust: false,
+            auth_key: None,
+        },
+    ];
+    let router = Router::new(&backends);
+    let matched = router.lookup("/service//foo").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:1010"), matched.backend.url);
+    assert_eq!("//foo", matched._path);
+    Ok(())
+}
+
+#[test]
+fn test_router_multiple_trailing_slashes() -> Result<()> {
+    let backends = vec![
+        Backend {
+            context: Some("/service///".to_string()),
+            url: Uri::from_static("http://localhost:1010"),
+            trust: false,
+            auth_key: None,
+        },
+        Backend {
+            context: None,
+            url: Uri::from_static("http://localhost:9999"),
+            trust: false,
+            auth_key: None,
+        },
+    ];
+    let router = Router::new(&backends);
+    let matched = router.lookup("/service/foo").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:9999"), matched.backend.url);
+    assert_eq!("service/foo", matched._path);
+    Ok(())
+}
+
+#[test]
+fn test_router_case_sensitivity() -> Result<()> {
+    let backends = vec![
+        Backend {
+            context: Some("/Service".to_string()),
+            url: Uri::from_static("http://localhost:1010"),
+            trust: false,
+            auth_key: None,
+        },
+        Backend {
+            context: None,
+            url: Uri::from_static("http://localhost:9999"),
+            trust: false,
+            auth_key: None,
+        },
+    ];
+    let router = Router::new(&backends);
+    let matched = router.lookup("/Service/foo").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:1010"), matched.backend.url);
+    assert_eq!("/foo", matched._path);
+    let matched = router.lookup("/service/foo").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:9999"), matched.backend.url);
+    Ok(())
+}
+
+#[test]
+fn test_router_url_encoded_path() -> Result<()> {
+    let backends = vec![
+        Backend {
+            context: Some("/service".to_string()),
+            url: Uri::from_static("http://localhost:1010"),
+            trust: false,
+            auth_key: None,
+        },
+    ];
+    let router = Router::new(&backends);
+    let matched = router.lookup("/service/path%2Fwith%2Fslashes").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:1010"), matched.backend.url);
+    assert_eq!("/path%2Fwith%2Fslashes", matched._path);
+    Ok(())
+}
+
+#[test]
+fn test_router_context_with_dot() -> Result<()> {
+    let backends = vec![
+        Backend {
+            context: Some("/api.v2".to_string()),
+            url: Uri::from_static("http://localhost:1010"),
+            trust: false,
+            auth_key: None,
+        },
+        Backend {
+            context: None,
+            url: Uri::from_static("http://localhost:9999"),
+            trust: false,
+            auth_key: None,
+        },
+    ];
+    let router = Router::new(&backends);
+    let matched = router.lookup("/api.v2/foo").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:1010"), matched.backend.url);
+    assert_eq!("/foo", matched._path);
+    let matched = router.lookup("/api/v2/foo").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:9999"), matched.backend.url);
+    Ok(())
+}
+
+#[test]
+fn test_router_context_dot_and_dotdot() -> Result<()> {
+    let backends = vec![
+        Backend {
+            context: Some("/.".to_string()),
+            url: Uri::from_static("http://localhost:1010"),
+            trust: false,
+            auth_key: None,
+        },
+        Backend {
+            context: Some("/..".to_string()),
+            url: Uri::from_static("http://localhost:2020"),
+            trust: false,
+            auth_key: None,
+        },
+    ];
+    let router = Router::new(&backends);
+    let matched = router.lookup("/.").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:1010"), matched.backend.url);
+    let matched = router.lookup("/..").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:2020"), matched.backend.url);
+    Ok(())
+}
+
+#[test]
+fn test_router_context_whitespace() -> Result<()> {
+    let backends = vec![
+        Backend {
+            context: Some("/service ".to_string()),
+            url: Uri::from_static("http://localhost:1010"),
+            trust: false,
+            auth_key: None,
+        },
+        Backend {
+            context: None,
+            url: Uri::from_static("http://localhost:9999"),
+            trust: false,
+            auth_key: None,
+        },
+    ];
+    let router = Router::new(&backends);
+    let matched = router.lookup("/service /foo").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:1010"), matched.backend.url);
+    assert_eq!("/foo", matched._path);
+    let matched = router.lookup("/service/foo").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:9999"), matched.backend.url);
+    Ok(())
+}
+
+#[test]
+fn test_router_params_empty_match() -> Result<()> {
+    let backends = vec![
+        Backend {
+            context: Some("/exact".to_string()),
+            url: Uri::from_static("http://localhost:1010"),
+            trust: false,
+            auth_key: None,
+        },
+    ];
+    let router = Router::new(&backends);
+    let matched = router.lookup("/exact").unwrap();
+    assert_eq!(Uri::from_static("http://localhost:1010"), matched.backend.url);
+    assert_eq!("", matched._path);
+    Ok(())
+}
+


### PR DESCRIPTION



## 🤖 New release

* `vicarian`: 0.2.5 -> 0.2.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.6](https://github.com/tarka/vicarian/compare/v0.2.5...v0.2.6) - 2026-05-26

### <!-- 1 -->Bug Fixes

- Add fix for bare-IPv6 port-stripping.
- Handle hostnames case-insensitively

### Other

- Add LLM-generated corner-case testing. One failing currently.
- Minor test fix
- Dependency upgrade
- Dependency bump.
- Add ACME renewal success/fail counters.
- Move metrics names into consts in metrics module and register/describe them up front.
- Minor dependency updates.
- Update github action version.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).