### PR TITLE
chore: release v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/tarka/vicarian/compare/v0.2.5...v0.2.6) - 2026-06-08
+
+### <!-- 1 -->Bug Fixes
+
+- We technically need the tokio  flag, although it's enabled by other dependencies.
+- Add fix for bare-IPv6 port-stripping.
+- Handle hostnames case-insensitively
+
+### <!-- 3 -->Documentation
+
+- Add SECURITY.md
+
+### Other
+
+- Bump dependencies; include Pingora security fixes.
+- We can use OnceLock rather than tokio-specific version
+- Minor test fix
+- Dependency upgrade
+- Dependency bump.
+- Add ACME renewal success/fail counters.
+- Move metrics names into consts in metrics module and register/describe them up front.
+- Minor dependency updates.
+- Update github action version.
+
 ## [0.2.5](https://github.com/tarka/vicarian/compare/v0.2.4...v0.2.5) - 2026-03-11
 
 ### <!-- 0 -->Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4276,7 +4276,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vicarian"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vicarian"
 description = "Vicarian is a reverse proxy server with ACME support"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2024"
 
 authors = ["Steve Smith <tarkasteve@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `vicarian`: 0.2.5 -> 0.2.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.6](https://github.com/tarka/vicarian/compare/v0.2.5...v0.2.6) - 2026-06-08

### <!-- 1 -->Bug Fixes

- We technically need the tokio  flag, although it's enabled by other dependencies.
- Add fix for bare-IPv6 port-stripping.
- Handle hostnames case-insensitively

### <!-- 3 -->Documentation

- Add SECURITY.md

### Other

- Bump dependencies; include Pingora security fixes.
- We can use OnceLock rather than tokio-specific version
- Minor test fix
- Dependency upgrade
- Dependency bump.
- Add ACME renewal success/fail counters.
- Move metrics names into consts in metrics module and register/describe them up front.
- Minor dependency updates.
- Update github action version.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).