### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### <!-- 0 -->Features
 
 - Add client compression handling.
-- *(config)* [**breaking**] Change backend path into a newtype and
+- *(config)* [**breaking**] `context` is now `path`; `context` will remain as an alias for the time being but is deprecated.
 
 ### <!-- 1 -->Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/tarka/vicarian/compare/v0.2.6...v0.3.0) - 2026-07-03
+
+### <!-- 0 -->Features
+
+- Add client compression handling.
+- *(config)* [**breaking**] Change backend path into a newtype and
+
+### <!-- 1 -->Bug Fixes
+
+- Disallow duplicate paths in backends.
+- Handle missing or malformed Host: headers
+- *(router)* Testing and fixes for path-matching corner cases.
+
+### <!-- 2 -->Refactor
+
+- *(config)* Backend path is no longer an option but defaults to "/" up-front rather than overriding in the router.
+- *(config)* context is now path (but remains backwards compatible.
+- *(config)* Use manual validation and sanitising; nutype is a bit overkill.
+- *(config)* Split CLI parsing into submodule.
+
+### <!-- 6 -->Testing
+
+- Add more integration test corner cases.
+- Always call validation on test backends.
+- Add more generated test corner-cases.
+- *(router)* Add more tests coverage for the router.
+
+### Other
+
+- Minor clippy fix
+- Fix release-plz config
+- Bump minor version for prerelease breaks.
+
 ## [0.2.6](https://github.com/tarka/vicarian/compare/v0.2.5...v0.2.6) - 2026-06-08
 
 ### <!-- 1 -->Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4270,7 +4270,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vicarian"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vicarian"
 description = "Vicarian is a reverse proxy server with ACME support"
-version = "0.2.6"
+version = "0.3.0"
 edition = "2024"
 
 authors = ["Steve Smith <tarkasteve@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `vicarian`: 0.2.6 -> 0.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/tarka/vicarian/compare/v0.2.6...v0.3.0) - 2026-07-03

### <!-- 0 -->Features

- Add client compression handling.
- *(config)* [**breaking**] Change backend path into a newtype and

### <!-- 1 -->Bug Fixes

- Disallow duplicate paths in backends.
- Handle missing or malformed Host: headers
- *(router)* Testing and fixes for path-matching corner cases.

### <!-- 2 -->Refactor

- *(config)* Backend path is no longer an option but defaults to "/" up-front rather than overriding in the router.
- *(config)* context is now path (but remains backwards compatible.
- *(config)* Use manual validation and sanitising; nutype is a bit overkill.
- *(config)* Split CLI parsing into submodule.

### <!-- 6 -->Testing

- Add more integration test corner cases.
- Always call validation on test backends.
- Add more generated test corner-cases.
- *(router)* Add more tests coverage for the router.

### Other

- Minor clippy fix
- Fix release-plz config
- Bump minor version for prerelease breaks.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).