### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### <!-- 0 -->Features
 
-- Initial very-rough PoC for using static-web-server
+- Support for static-file serving. See CONFIGURATION.md for details.
 - Add client compression handling.
-- *(config)* [**breaking**] Change backend path into a newtype and
 
 ### <!-- 1 -->Bug Fixes
 
@@ -36,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### <!-- 6 -->Testing
 
-- Generated tests for static functionality. Not passing yet.
+- Generated tests for static functionality.
 - Add more integration test corner cases.
 - Always call validation on test backends.
 - Add more generated test corner-cases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/tarka/vicarian/compare/v0.2.6...v0.3.0) - 2026-07-19
+
+### <!-- 0 -->Features
+
+- Initial very-rough PoC for using static-web-server
+- Add client compression handling.
+- *(config)* [**breaking**] Change backend path into a newtype and
+
+### <!-- 1 -->Bug Fixes
+
+- Disallow duplicate paths in backends.
+- Handle missing or malformed Host: headers
+- *(router)* Testing and fixes for path-matching corner cases.
+
+### <!-- 2 -->Refactor
+
+- *(config)* Backend path is no longer an option but defaults to "/" up-front rather than overriding in the router.
+- *(config)* context is now path (but remains backwards compatible.
+- *(config)* Use manual validation and sanitising; nutype is a bit overkill.
+- *(config)* Split CLI parsing into submodule.
+
+### <!-- 3 -->Documentation
+
+- Update website with static-file and metrics examples.
+- Update configuration docs with static config.
+- Update readme with static-file support.
+
+### <!-- 6 -->Testing
+
+- Generated tests for static functionality. Not passing yet.
+- Add more integration test corner cases.
+- Always call validation on test backends.
+- Add more generated test corner-cases.
+- *(router)* Add more tests coverage for the router.
+
+### <!-- 7 -->Miscellaneous Tasks
+
+- Update dependencies
+- Bump dependencies.
+
+### Other
+
+- Move some utility functions around.
+- Move non-TLS handling to own submodule.
+- Complete static handler and add metrics handler. All tests passing.
+- Fill out necessary data for static file integration tests.
+- More cleanup, initialise static_web_server on startup.
+- Interim checkin: Intial work of router handlers.
+- Minor clippy fix
+- Fix release-plz config
+- Bump minor version for prerelease breaks.
+
 ## [0.2.6](https://github.com/tarka/vicarian/compare/v0.2.5...v0.2.6) - 2026-06-08
 
 ### <!-- 1 -->Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4905,7 +4905,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vicarian"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vicarian"
 description = "Vicarian is a reverse proxy server with ACME support"
-version = "0.2.6"
+version = "0.3.0"
 edition = "2024"
 
 authors = ["Steve Smith <tarkasteve@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `vicarian`: 0.2.6 -> 0.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/tarka/vicarian/compare/v0.2.6...v0.3.0) - 2026-07-19

### <!-- 0 -->Features

- Support for static-file serving. See CONFIGURATION.md for details.
- Add client compression handling.

### <!-- 1 -->Bug Fixes

- Disallow duplicate paths in backends.
- Handle missing or malformed Host: headers
- *(router)* Testing and fixes for path-matching corner cases.

### <!-- 2 -->Refactor

- *(config)* Backend path is no longer an option but defaults to "/" up-front rather than overriding in the router.
- *(config)* context is now path (but remains backwards compatible.
- *(config)* Use manual validation and sanitising; nutype is a bit overkill.
- *(config)* Split CLI parsing into submodule.

### <!-- 3 -->Documentation

- Update website with static-file and metrics examples.
- Update configuration docs with static config.
- Update readme with static-file support.

### <!-- 6 -->Testing

- Generated tests for static functionality. Not passing yet.
- Add more integration test corner cases.
- Always call validation on test backends.
- Add more generated test corner-cases.
- *(router)* Add more tests coverage for the router.

### <!-- 7 -->Miscellaneous Tasks

- Update dependencies
- Bump dependencies.

### Other

- Move some utility functions around.
- Move non-TLS handling to own submodule.
- Complete static handler and add metrics handler. All tests passing.
- Fill out necessary data for static file integration tests.
- More cleanup, initialise static_web_server on startup.
- Interim checkin: Intial work of router handlers.
- Minor clippy fix
- Fix release-plz config
- Bump minor version for prerelease breaks.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).