### PR TITLE
chore: release v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.7](https://github.com/tarka/vicarian/compare/v0.2.6...v0.2.7) - 2026-07-20
+
+### <!-- 1 -->Bug Fixes
+
+- Vendor static-web-server for the time being as crates.io doesn't like git dependencies.
+
+### Other
+
+- Squashed 'vendor/static-web-server/' content from commit 13228a9
+
 ## [0.2.6](https://github.com/tarka/vicarian/compare/v0.2.5...v0.2.6) - 2026-06-08
 
 ### <!-- 1 -->Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4904,7 +4904,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vicarian"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vicarian"
 description = "Vicarian is a reverse proxy server with ACME support"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2024"
 
 authors = ["Steve Smith <tarkasteve@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vicarian"
 description = "Vicarian is a reverse proxy server with ACME support"
-version = "0.2.7"
+version = "0.3.0"
 edition = "2024"
 
 authors = ["Steve Smith <tarkasteve@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `vicarian`: 0.2.6 -> 0.2.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.7](https://github.com/tarka/vicarian/compare/v0.2.6...v0.2.7) - 2026-07-20

### <!-- 1 -->Bug Fixes

- Vendor static-web-server for the time being as crates.io doesn't like git dependencies.

### Other

- Squashed 'vendor/static-web-server/' content from commit 13228a9
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).