### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0](https://github.com/tarka/vicarian/compare/v0.2.6...v0.3.0) - 2026-07-20
 
-### <!-- 1 -->Bug Fixes
+### <!-- 1 -->Features
 
-- And release-plz doesn't like arbitrary versions.
-- Add a dummy version to the vendored library for crates.io
-- Vendor static-web-server for the time being as crates.io doesn't like git dependencies.
+- Add static-file support using static-file-server. See CONFIGURATION.md for details.
+- Compression is now enabled.
 
 ### <!-- 7 -->Miscellaneous Tasks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/tarka/vicarian/compare/v0.2.6...v0.3.0) - 2026-07-20
+
+### <!-- 1 -->Bug Fixes
+
+- And release-plz doesn't like arbitrary versions.
+- Add a dummy version to the vendored library for crates.io
+- Vendor static-web-server for the time being as crates.io doesn't like git dependencies.
+
+### <!-- 7 -->Miscellaneous Tasks
+
+- Bump to 0.3.0
+
+### Other
+
+- Squashed 'vendor/static-web-server/' content from commit 13228a9
+
 ## [0.2.6](https://github.com/tarka/vicarian/compare/v0.2.5...v0.2.6) - 2026-06-08
 
 ### <!-- 1 -->Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4096,7 +4096,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static-web-server"
-version = "2.43.0"
+version = "3.0.0-tarka.1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4904,7 +4904,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vicarian"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION



## 🤖 New release

* `vicarian`: 0.2.6 -> 0.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/tarka/vicarian/compare/v0.2.6...v0.3.0) - 2026-07-20

### <!-- 1 -->Features

- Add static-file support using static-file-server. See CONFIGURATION.md for details.
- Compression is now enabled.

### <!-- 7 -->Miscellaneous Tasks

- Bump to 0.3.0

### Other

- Squashed 'vendor/static-web-server/' content from commit 13228a9
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).