### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0](https://github.com/tarka/vicarian/compare/v0.2.6...v0.3.0) - 2026-07-21
 
-### <!-- 1 -->Bug Fixes
+### <!-- 1 -->Features
 
-- crates.io expects a valid version for a vendored crate
-- Vendor static-web-server for the time being as crates.io doesn't like git dependencies.
+- Add static file support using static-web-server library. See CONFIGURATION.md for detail.
 
 ### <!-- 7 -->Miscellaneous Tasks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/tarka/vicarian/compare/v0.2.6...v0.3.0) - 2026-07-21
+
+### <!-- 1 -->Bug Fixes
+
+- crates.io expects a valid version for a vendored crate
+- Vendor static-web-server for the time being as crates.io doesn't like git dependencies.
+
+### <!-- 7 -->Miscellaneous Tasks
+
+- Bump dependencies.
+- Bump to 0.3.0
+
+### Other
+
+- Squashed 'vendor/static-web-server/' content from commit 13228a9
+
 ## [0.2.6](https://github.com/tarka/vicarian/compare/v0.2.5...v0.2.6) - 2026-06-08
 
 ### <!-- 1 -->Bug Fixes


### PR DESCRIPTION



## 🤖 New release

* `vicarian`: 0.2.6 -> 0.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/tarka/vicarian/compare/v0.2.6...v0.3.0) - 2026-07-21

### <!-- 1 -->Features

- Add static file support using static-web-server library. See CONFIGURATION.md for detail.

### <!-- 7 -->Miscellaneous Tasks

- Bump dependencies.
- Bump to 0.3.0

### Other

- Squashed 'vendor/static-web-server/' content from commit 13228a9
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).