### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/tarka/vicarian/compare/v0.3.0...v0.3.1) - 2026-08-01
+
+### <!-- 3 -->Documentation
+
+- Change AI/LLM policy to "none"
+
+### Other
+
+- Add simple inline SVG favicon.
+- Update dependencies, and move the the now-beta upstream static-web-server
+
 ## [0.3.0](https://github.com/tarka/vicarian/compare/v0.2.6...v0.3.0) - 2026-07-21
 
 ### <!-- 1 -->Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4912,7 +4912,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vicarian"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vicarian"
 description = "Vicarian is a reverse proxy server with ACME support"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 
 authors = ["Steve Smith <tarkasteve@gmail.com>"]

--- a/docs/website/index.html
+++ b/docs/website/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Vicarian - Reverse Proxy with ACME Support</title>
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><defs><linearGradient id='g' x1='0%25' y1='0%25' x2='100%25' y2='100%25'><stop offset='0%25' stop-color='%232563EB'/><stop offset='100%25' stop-color='%230F172A'/></linearGradient></defs><rect width='512' height='512' rx='112' fill='url(%23g)'/><path d='M 128 140 L 216 140 L 256 280 L 296 140 L 384 140 L 288 380 L 224 380 Z' fill='%23FFFFFF'/><path d='M 296 140 L 384 140 L 288 380 L 256 380 Z' fill='%2338BDF8' opacity='0.85'/></svg>">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <!-- Arborium syntax highlighting -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@arborium/arborium/dist/themes/github-dark.css">


### PR DESCRIPTION



## 🤖 New release

* `vicarian`: 0.3.0 -> 0.3.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/tarka/vicarian/compare/v0.3.0...v0.3.1) - 2026-08-01

### <!-- 3 -->Documentation

- Change AI/LLM policy to "none"

### Other

- Add simple inline SVG favicon.
- Update dependencies, and move the the now-beta upstream static-web-server
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).