### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.1](https://github.com/tarka/vicarian/compare/v0.3.0...v0.3.1) - 2026-08-03
 
+- Add build and upload of .deb packages.
+
 ### <!-- 3 -->Documentation
 
 - Add basic static file config example.
@@ -16,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- Add build and upload of .deb packages.
 - Add support for building .deb packages with cargo-deb
 - Add simple inline SVG favicon.
 - Update dependencies, and move the the now-beta upstream static-web-server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/tarka/vicarian/compare/v0.3.0...v0.3.1) - 2026-08-03
+
+### <!-- 3 -->Documentation
+
+- Add basic static file config example.
+- Change AI/LLM policy to "none"
+
+### Other
+
+- Add build and upload of .deb packages.
+- Add support for building .deb packages with cargo-deb
+- Add simple inline SVG favicon.
+- Update dependencies, and move the the now-beta upstream static-web-server
+
 ## [0.3.0](https://github.com/tarka/vicarian/compare/v0.2.6...v0.3.0) - 2026-07-21
 
 ### <!-- 1 -->Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4912,7 +4912,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vicarian"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vicarian"
 description = "Vicarian is a TLS-first reverse-proxy server with ACME support"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 
 authors = ["Steve Smith <tarkasteve@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `vicarian`: 0.3.0 -> 0.3.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/tarka/vicarian/compare/v0.3.0...v0.3.1) - 2026-08-03

### <!-- 3 -->Documentation

- Add basic static file config example.
- Change AI/LLM policy to "none"

### Other

- Add build and upload of .deb packages.
- Add support for building .deb packages with cargo-deb
- Add simple inline SVG favicon.
- Update dependencies, and move the the now-beta upstream static-web-server
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).