### PR TITLE
chore: release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/tarka/vicarian/compare/v0.3.2...v0.3.3) - 2026-08-18
+
+### <!-- 1 -->Bug Fixes
+
+- *(acme)* Add additional record test when polling DNS to ensure we have the right entry.
+- *(acme)* Delete all matching DNS-01 ACME records on cleanup to prevent a pile-up of stale entries.
+
+### <!-- 3 -->Documentation
+
+- Simplify deb instructions.
+- Add instructions for Debian package installation.
+
+### Other
+
+- Update to latest zone-update, and other dependencies.
+
 ## [0.3.2](https://github.com/tarka/vicarian/compare/v0.3.1...v0.3.2) - 2026-08-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4927,7 +4927,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vicarian"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vicarian"
 description = "Vicarian is a TLS-first reverse-proxy server with ACME support"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 
 authors = ["Steve Smith <tarkasteve@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `vicarian`: 0.3.2 -> 0.3.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.3](https://github.com/tarka/vicarian/compare/v0.3.2...v0.3.3) - 2026-08-18

### <!-- 1 -->Bug Fixes

- *(acme)* Add additional record test when polling DNS to ensure we have the right entry.
- *(acme)* Delete all matching DNS-01 ACME records on cleanup to prevent a pile-up of stale entries.

### <!-- 3 -->Documentation

- Simplify deb instructions.
- Add instructions for Debian package installation.

### Other

- Update to latest zone-update, and other dependencies.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).